### PR TITLE
Markdownify: render markdown into html

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -38,6 +38,9 @@ end
 # Use unicorn as the app server
 # gem 'unicorn'
 
+# Use redcarpet to render markdown
+gem 'redcarpet'
+
 # Use Capistrano for deployment
 # gem 'capistrano', group: :development
 

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,7 +1,7 @@
 module ApplicationHelper
   def signed_in?
     # check for ID because we always have a current user
-    current_user.id.present?
+    current_user && current_user.id.present?
   end
 
   def nav_link(link_text, link_path, html_opts = {})

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -10,5 +10,11 @@ module ApplicationHelper
 	  content_tag(:li, :class => "#{html_opts[:class]} #{active}") do
 	    link_to link_text, link_path
 	  end
-	end
+  end
+
+  def markdownify(content)
+  	@@markdown ||= Redcarpet::Markdown.new(Redcarpet::Render::HTML, :autolink => true, :space_after_headers => true)
+  	@@markdown.render(content)
+  end
+
 end

--- a/app/views/projects/index.html.erb
+++ b/app/views/projects/index.html.erb
@@ -18,7 +18,7 @@
       <% @projects.each do |project| %>
         <tr>
           <td><%= project.name %></td>
-          <td><%= project.description %></td>
+          <td><%= markdownify(project.description).html_safe%></td>
           <td><%= project.user_id %></td>
           <td><%= link_to 'Show', project if can_read?(project) %></td>
           <td><%= link_to 'Edit', edit_project_path(project) if can_update?(project) %></td>

--- a/app/views/projects/show.html.erb
+++ b/app/views/projects/show.html.erb
@@ -10,7 +10,7 @@
     </p>
 
     <p class="description">
-      <%= @project.description %>
+      <%= markdownify(@project.description).html_safe %>
     </p>
   </section>
 
@@ -19,7 +19,7 @@
       <% @project.steps.each_with_index do |step, index| %>
         <li>
           <span class="step-number"><%= index + 1 %></span>
-          <%= step.content %>
+          <%= markdownify(step.content).html_safe %>
         </li>
       <% end %>
     </ol>


### PR DESCRIPTION
Added to description of projects in the list and the item-view as well as to the content per step. Examples as one can see. 

![bildschirmfoto 2013-07-16 um 23 42 18](https://f.cloud.github.com/assets/40496/808573/dc956756-ee66-11e2-9bb3-1e26bfbf3a9e.png)
![bildschirmfoto 2013-07-16 um 23 42 27](https://f.cloud.github.com/assets/40496/808575/e17dbba6-ee66-11e2-9953-9bf8d957b61a.png)

It is based on the redcarpet plugin and as such requires to rerun 'bundle' after merging in order to install it. Happy hacking.
